### PR TITLE
Update rtp.c

### DIFF
--- a/driver/common/rtp.c
+++ b/driver/common/rtp.c
@@ -482,6 +482,7 @@ void RTPSessionDestroy( struct RTPSession * session ) {
     }
   }
   free( session->buffer );
+  close( session->socket );
   free( session );
 }
 


### PR DESCRIPTION
Closing RTP session's socket. This is a critical issue as it may block a socket for process life time, can cause leaking of descriptor and may lead to a crash if process's max limit of file descriptor is reached.
