### PR TITLE
applemidi.c: Fix _applemidi_connect() err handling

### DIFF
--- a/driver/applemidi/applemidi.c
+++ b/driver/applemidi/applemidi.c
@@ -185,7 +185,7 @@ static int _applemidi_bind( int fd, int port ) {
 
 
 static int _applemidi_connect( struct MIDIDriverAppleMIDI * driver ) {
-  int result = 0;
+  int result = -1;
 #if (defined(AF_INET6) && defined(ENABLE_IPV6))
   int pf = PF_INET6;
 #else
@@ -196,16 +196,12 @@ static int _applemidi_connect( struct MIDIDriverAppleMIDI * driver ) {
     driver->control_socket = socket( pf, SOCK_DGRAM, 0 );
     if( driver->control_socket != -1 )
       result = _applemidi_bind( driver->control_socket, driver->port );
-    else
-      result = -1;
   }
 
   if( result == 0 && driver->rtp_socket <= 0 ) {
     driver->rtp_socket = socket( pf, SOCK_DGRAM, 0 );
     if( driver->rtp_socket != -1 )
       result = _applemidi_bind( driver->rtp_socket, driver->port + 1 );
-    else
-      result = -1;
   }
 
   return result;


### PR DESCRIPTION
The return variable `result` is initialized with `0`, and is not updated in case the system call `socket()` call fails. In this case, the function `_applemidi_connect()` returns 0, a success value.

Fix this, by error checking for failure of `socket()` call. 
We set `result = -1;` in error case, because this is what is checked for, in `MIDIDriverAppleMIDICreate()` line 311.
