### PR TITLE
Add missing Null check for allocation failure.

### DIFF
--- a/driver/common/rtp.c
+++ b/driver/common/rtp.c
@@ -284,6 +284,7 @@ struct RTPSession {
  */
 struct RTPPeer * RTPPeerCreate( unsigned long ssrc, socklen_t size, struct sockaddr * addr ) {
   struct RTPPeer * peer = malloc( sizeof( struct RTPPeer ) );
+  if( peer == NULL ) return NULL;
   peer->refs = 1;
   peer->address.ssrc = ssrc;
   peer->address.size = size;
@@ -430,8 +431,10 @@ static void _session_randomize_ssrc( struct RTPSession * session ) {
  * @return a @c NULL pointer if the controller could not created.
  */
 struct RTPSession * RTPSessionCreate( int socket ) {
-  struct RTPSession * session = malloc( sizeof( struct RTPSession ) );
   int i;
+  struct RTPSession * session = malloc( sizeof( struct RTPSession ) );
+  if( session == NULL ) return NULL;
+
   session->refs   = 1;
   session->socket = socket;
 

--- a/driver/osc/osc.c
+++ b/driver/osc/osc.c
@@ -42,6 +42,7 @@ static int _osc_bind( int fd, int port ) {
 
 struct MIDIDriverOSC * MIDIDriverOSCCreate( ) {
   struct MIDIDriverOSC * driver = malloc( sizeof( struct MIDIDriverOSC ) );
+  if( driver == NULL ) return NULL;
 
   driver->refs = 1;
 #if (defined(AF_INET6) && defined(ENABLE_IPV6))


### PR DESCRIPTION
Null check missed for allocation failure at couple of places.